### PR TITLE
Add xTaskGetIdleTaskHandleForCore for SMP

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1882,24 +1882,24 @@
     #define traceRETURN_uxTaskGetSystemState( uxTask )
 #endif
 
-#ifndef traceENTER_xTaskGetIdleTaskHandle
-    #define traceENTER_xTaskGetIdleTaskHandle()
-#endif
-
-#if ( configNUMBER_OF_CORES > 1 )
-    #ifndef traceENTER_xTaskGetIdleTaskHandleForCore
-        #define traceENTER_xTaskGetIdleTaskHandleForCore( xCoreID )
+#if ( configNUMBER_OF_CORES == 1 )
+    #ifndef traceENTER_xTaskGetIdleTaskHandle
+        #define traceENTER_xTaskGetIdleTaskHandle()
     #endif
 #endif
 
-#ifndef traceRETURN_xTaskGetIdleTaskHandle
-    #define traceRETURN_xTaskGetIdleTaskHandle( xIdleTaskHandle )
+#if ( configNUMBER_OF_CORES == 1 )
+    #ifndef traceRETURN_xTaskGetIdleTaskHandle
+        #define traceRETURN_xTaskGetIdleTaskHandle( xIdleTaskHandle )
+    #endif
 #endif
 
-#if ( configNUMBER_OF_CORES > 1 )
-    #ifndef traceRETURN_xTaskGetIdleTaskHandleForCore
-        #define traceRETURN_xTaskGetIdleTaskHandleForCore( xIdleTaskHandle )
-    #endif
+#ifndef traceENTER_xTaskGetIdleTaskHandleForCore
+    #define traceENTER_xTaskGetIdleTaskHandleForCore( xCoreID )
+#endif
+
+#ifndef traceRETURN_xTaskGetIdleTaskHandleForCore
+    #define traceRETURN_xTaskGetIdleTaskHandleForCore( xIdleTaskHandle )
 #endif
 
 #ifndef traceENTER_vTaskStepTick

--- a/include/task.h
+++ b/include/task.h
@@ -2045,10 +2045,10 @@ BaseType_t xTaskCallApplicationTaskHook( TaskHandle_t xTask,
  * idle task handle. Call xTaskGetIdleTaskHandleForCore() with xCoreID set to
  * 1,2 ... ( configNUMBER_OF_CORES - 1 ) to get the Passive idle task handles.
  */
-TaskHandle_t xTaskGetIdleTaskHandle( void ) PRIVILEGED_FUNCTION;
-#if ( configNUMBER_OF_CORES > 1 )
-    TaskHandle_t xTaskGetIdleTaskHandleForCore( BaseType_t xCoreID ) PRIVILEGED_FUNCTION;
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+#if ( configNUMBER_OF_CORES == 1 )
+    TaskHandle_t xTaskGetIdleTaskHandle( void ) PRIVILEGED_FUNCTION;
+#endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+TaskHandle_t xTaskGetIdleTaskHandleForCore( BaseType_t xCoreID ) PRIVILEGED_FUNCTION;
 
 /**
  * configUSE_TRACE_FACILITY must be defined as 1 in FreeRTOSConfig.h for

--- a/tasks.c
+++ b/tasks.c
@@ -4455,7 +4455,6 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
 #if ( INCLUDE_xTaskGetIdleTaskHandle == 1 )
 
     #if ( configNUMBER_OF_CORES == 1 )
-
         TaskHandle_t xTaskGetIdleTaskHandle( void )
         {
             traceENTER_xTaskGetIdleTaskHandle();
@@ -4468,39 +4467,23 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
 
             return xIdleTaskHandles[ 0 ];
         }
-
-    #else /* if ( configNUMBER_OF_CORES == 1 ) */
-
-        TaskHandle_t xTaskGetIdleTaskHandle( void )
-        {
-            traceENTER_xTaskGetIdleTaskHandle();
-
-            /* If xTaskGetIdleTaskHandle() is called before the scheduler has been
-             * started, then xIdleTaskHandles will be NULL. */
-            configASSERT( ( xIdleTaskHandles[ portGET_CORE_ID() ] != NULL ) );
-
-            traceRETURN_xTaskGetIdleTaskHandle( xIdleTaskHandles[ portGET_CORE_ID() ] );
-
-            return xIdleTaskHandles[ portGET_CORE_ID() ];
-        }
-
-        TaskHandle_t xTaskGetIdleTaskHandleForCore( BaseType_t xCoreID )
-        {
-            traceENTER_xTaskGetIdleTaskHandleForCore( xCoreID );
-
-            /* Ensure the core ID is valid. */
-            configASSERT( taskVALID_CORE_ID( xCoreID ) == pdTRUE );
-
-            /* If xTaskGetIdleTaskHandle() is called before the scheduler has been
-             * started, then xIdleTaskHandles will be NULL. */
-            configASSERT( ( xIdleTaskHandles[ xCoreID ] != NULL ) );
-
-            traceRETURN_xTaskGetIdleTaskHandleForCore( xIdleTaskHandles[ xCoreID ] );
-
-            return xIdleTaskHandles[ xCoreID ];
-        }
-
     #endif /* if ( configNUMBER_OF_CORES == 1 ) */
+
+    TaskHandle_t xTaskGetIdleTaskHandleForCore( BaseType_t xCoreID )
+    {
+        traceENTER_xTaskGetIdleTaskHandleForCore( xCoreID );
+
+        /* Ensure the core ID is valid. */
+        configASSERT( taskVALID_CORE_ID( xCoreID ) == pdTRUE );
+
+        /* If xTaskGetIdleTaskHandle() is called before the scheduler has been
+         * started, then xIdleTaskHandles will be NULL. */
+        configASSERT( ( xIdleTaskHandles[ xCoreID ] != NULL ) );
+
+        traceRETURN_xTaskGetIdleTaskHandleForCore( xIdleTaskHandles[ xCoreID ] );
+
+        return xIdleTaskHandles[ xCoreID ];
+    }
 
 #endif /* INCLUDE_xTaskGetIdleTaskHandle */
 /*----------------------------------------------------------*/


### PR DESCRIPTION
PR suggestion

Description
-----------
* `xTaskGetIdleTaskHandleForCore` is also available in single-core to enable a SMP application built with single-core.
* `xTaskGetIdleTaskHandle` is not available in SMP to prevent application assume only one idle task in system. User can still use `xTaskGetIdleTaskHandleForCore( 0 )` to acquire active idle task handle.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
